### PR TITLE
Fix responsible-is-group input

### DIFF
--- a/actions/create-task/action.php
+++ b/actions/create-task/action.php
@@ -13,7 +13,7 @@ $optionsConfig = [
     'responsible:',         // string (required)
     'responsibleIsGroup::', // int [0|1] (default: 1)
     'editor::',             // string
-    'projects::',            // string (comma-separated list of ids)
+    'projects::',           // string (comma-separated list of ids)
 ];
 $options = getopt('', $optionsConfig);
 

--- a/actions/create-task/action.yml
+++ b/actions/create-task/action.yml
@@ -68,6 +68,6 @@ runs:
           --text="${{ inputs.text }}" \
           --type="${{ inputs.type }}" \
           --responsible="${{ inputs.responsible }}" \
-          --responsibleIsGroup="${{ inputs.responsibleIsGroup }}" \
+          --responsibleIsGroup="${{ inputs.responsible-is-group }}" \
           --editor="${{ inputs.editor }}" \
           --projects="${{ inputs.projects }}" 


### PR DESCRIPTION
Fixes responsible-is-group input which is not used at the moment because of a typo